### PR TITLE
fix screener being created as an advisor bug

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -79,7 +79,7 @@ class User(UserMixin, db.Model):
                     permissions=Permission.ADMINISTER).first()
             if self.email == current_app.config['SCREENER_EMAIL']:
                 self.role = Role.query.filter_by(
-                    permissions=Permission.ADVISOR).first()
+                    permissions=Permission.SCREENER).first()
             if self.email == current_app.config['ADVISOR_EMAIL']:
                 self.role = Role.query.filter_by(
                     permissions=Permission.ADVISOR).first()


### PR DESCRIPTION
## Description
Screener was originally being created as an advisor after running `python manage.py setup_dev`
Fixes https://github.com/hack4impact/immigrant-defense-project/issues/28

## Testing
Looked @ the DB after running `python manage.py recreate_db && python manage.py setup_dev`

## Reviewers 
> Tag one or two teammates to review your code. Ideally, you should tag people who have worked on the same files or similar features to notify them of your changes. If you pair programmed with someone, please indicate that here as well.

## Checklist
- [ ] I ran `python manage.py format` to autoformat my code according to the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
